### PR TITLE
fix don't search roots in the past on checkout. just return error if you cannot find the root

### DIFF
--- a/internal/state/v1/state.go
+++ b/internal/state/v1/state.go
@@ -369,12 +369,7 @@ func (t *tx) Checkout(contract common.Address, blockNumber int64) error {
 		return fmt.Errorf("contract %s does not exist", contract.String())
 	}
 
-	blockNumber, err := enumeratedTree.FindBlockWithTag(blockNumber)
-	if err != nil {
-		return err
-	}
-
-	err = enumeratedTree.Checkout(blockNumber)
+	err := enumeratedTree.Checkout(blockNumber)
 	if err != nil {
 		return err
 	}

--- a/internal/state/v1/state_test.go
+++ b/internal/state/v1/state_test.go
@@ -174,33 +174,6 @@ func TestMinting(t *testing.T) {
 	})
 }
 
-func TestTag(t *testing.T) {
-	t.Parallel()
-	t.Run(`test tag`, func(t *testing.T) {
-		t.Parallel()
-		t.Helper()
-		ctrl := gomock.NewController(t)
-
-		memoryService := memory.New()
-		stateService := v1.NewStateService(memoryService)
-
-		tx := stateService.NewTransaction()
-
-		enumeratedTree := enumeratedTreeMock.NewMockTree(ctrl)
-		enumeratedTotalTree := enumeratedTotalTreeMock.NewMockTree(ctrl)
-		ownershipTree := ownershipTreeMock.NewMockTree(ctrl)
-
-		tx.SetTreesForContract(common.HexToAddress("0x500"), ownershipTree, enumeratedTree, enumeratedTotalTree)
-
-		enumeratedTotalTree.EXPECT().TagRoot(int64(1)).Return(nil)
-		enumeratedTree.EXPECT().TagRoot(int64(1)).Return(nil)
-		ownershipTree.EXPECT().TagRoot(int64(1)).Return(nil)
-
-		err := tx.TagRoot(common.HexToAddress("0x500"), int64(1))
-		assert.NilError(t, err)
-	})
-}
-
 func TestCheckout(t *testing.T) {
 	t.Parallel()
 	t.Run(`test checkout`, func(t *testing.T) {

--- a/internal/state/v1/state_test.go
+++ b/internal/state/v1/state_test.go
@@ -219,13 +219,11 @@ func TestCheckout(t *testing.T) {
 
 		tx.SetTreesForContract(common.HexToAddress("0x500"), ownershipTree, enumeratedTree, enumeratedTotalTree)
 
-		enumeratedTree.EXPECT().FindBlockWithTag(int64(5)).Return(int64(1), nil)
-
 		enumeratedTotalTree.EXPECT().Checkout(int64(1)).Return(nil)
 		enumeratedTree.EXPECT().Checkout(int64(1)).Return(nil)
 		ownershipTree.EXPECT().Checkout(int64(1)).Return(nil)
 
-		err := tx.Checkout(common.HexToAddress("0x500"), int64(5))
+		err := tx.Checkout(common.HexToAddress("0x500"), int64(1))
 		assert.NilError(t, err)
 	})
 }


### PR DESCRIPTION
…case you cannot find the root