### PR TITLE
cleaning some debug logs

### DIFF
--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"math/big"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
@@ -205,7 +204,7 @@ func (s scanner) ScanNewUniversalEvents(ctx context.Context, fromBlock, toBlock 
 	}
 
 	if len(contracts) > 0 {
-		slog.Info("found " + strconv.Itoa(len(contracts)) + " new universal contracts")
+		slog.Info("universal contracts found", "contracts", len(contracts))
 	}
 
 	return contracts, nil
@@ -213,6 +212,7 @@ func (s scanner) ScanNewUniversalEvents(ctx context.Context, fromBlock, toBlock 
 
 // ScanEvents returns the ERC721 events between fromBlock and toBlock
 func (s scanner) ScanEvents(ctx context.Context, fromBlock, toBlock *big.Int, contracts []string) ([]Event, *big.Int, error) { // TODO change contracts from []string to ...string
+	slog.Info("scanning universal events ", "fromBlock", fromBlock, "toBlock", toBlock)
 	var lastBlock *big.Int
 	lastBlock = fromBlock
 	var addresses []common.Address
@@ -246,7 +246,6 @@ func (s scanner) ScanEvents(ctx context.Context, fromBlock, toBlock *big.Int, co
 
 	var parsedEvents []Event
 	for i := range eventLogs {
-		slog.Info("scanning event", "block", eventLogs[i].BlockNumber, "txHash", eventLogs[i].TxHash)
 		if len(eventLogs[i].Topics) > 0 {
 			switch eventLogs[i].Topics[0].Hex() {
 			// Ownership events

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math/big"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
@@ -159,6 +160,7 @@ func NewScanner(client EthClient, contracts ...string) Scanner {
 
 // ScanEvents returns the ERC721 events between fromBlock and toBlock
 func (s scanner) ScanNewUniversalEvents(ctx context.Context, fromBlock, toBlock *big.Int) ([]model.ERC721UniversalContract, error) {
+	slog.Info("scanning universal events ", "fromBlock", fromBlock, "toBlock", toBlock)
 	eventLogs, err := s.filterEventLogs(ctx, fromBlock, toBlock, s.contracts...)
 	if err != nil {
 		return nil, fmt.Errorf("error filtering events: %w", err)
@@ -176,13 +178,11 @@ func (s scanner) ScanNewUniversalEvents(ctx context.Context, fromBlock, toBlock 
 
 	contracts := make([]model.ERC721UniversalContract, 0)
 	for i := range eventLogs {
-		slog.Info("scanning event", "block", eventLogs[i].BlockNumber, "txHash", eventLogs[i].TxHash)
 		if len(eventLogs[i].Topics) == 0 {
 			continue
 		}
 
-		switch eventLogs[i].Topics[0].Hex() {
-		case eventNewERC721UniversalSigHash:
+		if eventLogs[i].Topics[0].Hex() == eventNewERC721UniversalSigHash {
 			newERC721Universal, err := parseNewERC721Universal(&eventLogs[i], &contractAbi)
 			if err != nil {
 				return nil, err
@@ -201,10 +201,11 @@ func (s scanner) ScanNewUniversalEvents(ctx context.Context, fromBlock, toBlock 
 				BlockNumber:       newERC721Universal.BlockNumber,
 			}
 			contracts = append(contracts, c)
-
-		default:
-			slog.Debug("no new universal contracts found")
 		}
+	}
+
+	if len(contracts) > 0 {
+		slog.Info("found " + strconv.Itoa(len(contracts)) + " new universal contracts")
 	}
 
 	return contracts, nil


### PR DESCRIPTION
optimize a bit of log writing. it was printing too many `no new universal contracts found` for every event when that was found. For me it was impossible to see anything useful in Grafana due to many of these logs.