### PR TITLE
Bugfix: changing BlockByNumber to HeaderByNumber

### DIFF
--- a/internal/core/processor/universal/processor.go
+++ b/internal/core/processor/universal/processor.go
@@ -122,7 +122,7 @@ func (p *processor) VerifyChainConsistency(ctx context.Context, startingBlock ui
 	// if it differs, it indicates a reorganization has taken place.
 	previousLastBlock := startingBlock - 1
 	slog.Debug("verifying chain consistency on block number", "previousLastBlock", previousLastBlock)
-	previousLastBlockData, err := p.client.BlockByNumber(ctx, big.NewInt(int64(previousLastBlock)))
+	previousLastBlockData, err := p.client.HeaderByNumber(ctx, big.NewInt(int64(previousLastBlock)))
 	if err != nil {
 		slog.Error("error occurred while retrieving new start range block", "err", err.Error())
 		return err
@@ -212,15 +212,15 @@ func (p *processor) ProcessUniversalBlockRange(ctx context.Context, startingBloc
 }
 
 func getLastBlockData(ctx context.Context, client blockchain.EthClient, lastBlock uint64) (model.Block, error) {
-	block, err := client.BlockByNumber(ctx, big.NewInt(int64(lastBlock)))
+	header, err := client.HeaderByNumber(ctx, big.NewInt(int64(lastBlock)))
 	if err != nil {
-		slog.Error("error occurred retrieving ownership end range block", "lastBlock", lastBlock, "err", err.Error())
+		slog.Error("error occurred retrieving ownership end range block from L1", "lastBlock", lastBlock, "err", err.Error())
 		return model.Block{}, err
 	}
 
 	return model.Block{
 		Number:    lastBlock,
-		Timestamp: block.Header().Time,
-		Hash:      block.Hash(),
+		Timestamp: header.Time,
+		Hash:      header.Hash(),
 	}, nil
 }

--- a/internal/core/processor/universal/processor_test.go
+++ b/internal/core/processor/universal/processor_test.go
@@ -173,7 +173,7 @@ func TestVerifyChainConsistency(t *testing.T) {
 		startingBlock          uint64
 		lastBlockDB            model.Block
 		lastBlockDBError       error
-		previousBlockData      *types.Block
+		previousBlockData      *types.Header
 		previousBlockDataError error
 		expectedError          error
 	}{
@@ -196,7 +196,7 @@ func TestVerifyChainConsistency(t *testing.T) {
 			startingBlock:     100,
 			lastBlockDB:       model.Block{Hash: common.HexToHash("0x558af54aec2a3b01640511cfc1d2b5772373b7b73ff621225031de3cae9a2c3e")},
 			lastBlockDBError:  nil,
-			previousBlockData: types.NewBlockWithHeader(&types.Header{ParentHash: common.HexToHash("0x123")}),
+			previousBlockData: &types.Header{ParentHash: common.HexToHash("0x123")},
 			expectedError:     nil,
 		},
 
@@ -215,7 +215,7 @@ func TestVerifyChainConsistency(t *testing.T) {
 			startingBlock:          100,
 			lastBlockDB:            model.Block{Hash: common.HexToHash("0x123")},
 			lastBlockDBError:       nil,
-			previousBlockData:      types.NewBlockWithHeader(&types.Header{ParentHash: common.HexToHash("0x123")}),
+			previousBlockData:      &types.Header{ParentHash: common.HexToHash("0x123")},
 			previousBlockDataError: nil,
 			expectedError: universal.ReorgError{
 				Block:       99,
@@ -237,7 +237,7 @@ func TestVerifyChainConsistency(t *testing.T) {
 			tx.EXPECT().Discard()
 
 			if tt.lastBlockDBError == nil && tt.lastBlockDB.Hash != (common.Hash{}) {
-				client.EXPECT().BlockByNumber(ctx, big.NewInt(int64(tt.startingBlock-1))).
+				client.EXPECT().HeaderByNumber(ctx, big.NewInt(int64(tt.startingBlock-1))).
 					Return(tt.previousBlockData, tt.previousBlockDataError)
 			}
 
@@ -258,10 +258,10 @@ func TestProcessUniversalBlockRange(t *testing.T) {
 	startingBlock := uint64(100)
 	stateService.EXPECT().NewTransaction().Return(tx)
 
-	block := types.NewBlockWithHeader(&types.Header{Number: big.NewInt(100)})
+	blockHeader := &types.Header{Number: big.NewInt(100)}
 	blockData := model.Block{Number: 100, Hash: common.HexToHash("0xb07e1289b32edefd8f3c702d016fb73c81d5950b2ebc790ad9d2cb8219066b4c")}
 
-	client.EXPECT().BlockByNumber(ctx, big.NewInt(100)).Return(block, nil)
+	client.EXPECT().HeaderByNumber(ctx, big.NewInt(100)).Return(blockHeader, nil)
 	tx.EXPECT().SetLastOwnershipBlock(blockData).Return(nil)
 	discoverer.EXPECT().ShouldDiscover(tx, startingBlock, blockData.Number).Return(false, nil)
 	discoverer.EXPECT().GetContracts(tx).Return([]string{"contract"}, nil)


### PR DESCRIPTION
Fixing an issue we found with a node in polygon mumbai
(https://mumbai.polygonscan.com/block/44537280)
doing an call to BlockByNumber with go-ethereum returns an error: server returned non-empty transaction list but block header indicates no transactions