### PR TITLE
don't store array in leaf of enumerated tree. store each tokenId in a separate leaf

### DIFF
--- a/deployment/charts/universalnode/templates/statefulset.yaml
+++ b/deployment/charts/universalnode/templates/statefulset.yaml
@@ -65,4 +65,4 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 10Gi
+          storage: 100Gi

--- a/internal/platform/state/tree/enumerated/mock/tree.go
+++ b/internal/platform/state/tree/enumerated/mock/tree.go
@@ -40,6 +40,21 @@ func (m *MockTree) EXPECT() *MockTreeMockRecorder {
 	return m.recorder
 }
 
+// BalanceOfOwner mocks base method.
+func (m *MockTree) BalanceOfOwner(owner common.Address) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BalanceOfOwner", owner)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BalanceOfOwner indicates an expected call of BalanceOfOwner.
+func (mr *MockTreeMockRecorder) BalanceOfOwner(owner any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BalanceOfOwner", reflect.TypeOf((*MockTree)(nil).BalanceOfOwner), owner)
+}
+
 // Checkout mocks base method.
 func (m *MockTree) Checkout(blockNumber int64) error {
 	m.ctrl.T.Helper()
@@ -97,6 +112,34 @@ func (mr *MockTreeMockRecorder) Root() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Root", reflect.TypeOf((*MockTree)(nil).Root))
 }
 
+// SetBalanceToOwner mocks base method.
+func (m *MockTree) SetBalanceToOwner(owner common.Address, balance uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetBalanceToOwner", owner, balance)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetBalanceToOwner indicates an expected call of SetBalanceToOwner.
+func (mr *MockTreeMockRecorder) SetBalanceToOwner(owner, balance any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBalanceToOwner", reflect.TypeOf((*MockTree)(nil).SetBalanceToOwner), owner, balance)
+}
+
+// SetTokenToOwnerToIndex mocks base method.
+func (m *MockTree) SetTokenToOwnerToIndex(owner common.Address, idx uint64, token *big.Int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetTokenToOwnerToIndex", owner, idx, token)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetTokenToOwnerToIndex indicates an expected call of SetTokenToOwnerToIndex.
+func (mr *MockTreeMockRecorder) SetTokenToOwnerToIndex(owner, idx, token any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTokenToOwnerToIndex", reflect.TypeOf((*MockTree)(nil).SetTokenToOwnerToIndex), owner, idx, token)
+}
+
 // TagRoot mocks base method.
 func (m *MockTree) TagRoot(blockNumber int64) error {
 	m.ctrl.T.Helper()
@@ -111,19 +154,19 @@ func (mr *MockTreeMockRecorder) TagRoot(blockNumber any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagRoot", reflect.TypeOf((*MockTree)(nil).TagRoot), blockNumber)
 }
 
-// TokensOf mocks base method.
-func (m *MockTree) TokensOf(owner common.Address) ([]big.Int, error) {
+// TokenOfOwnerByIndex mocks base method.
+func (m *MockTree) TokenOfOwnerByIndex(owner common.Address, idx uint64) (*big.Int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TokensOf", owner)
-	ret0, _ := ret[0].([]big.Int)
+	ret := m.ctrl.Call(m, "TokenOfOwnerByIndex", owner, idx)
+	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// TokensOf indicates an expected call of TokensOf.
-func (mr *MockTreeMockRecorder) TokensOf(owner any) *gomock.Call {
+// TokenOfOwnerByIndex indicates an expected call of TokenOfOwnerByIndex.
+func (mr *MockTreeMockRecorder) TokenOfOwnerByIndex(owner, idx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokensOf", reflect.TypeOf((*MockTree)(nil).TokensOf), owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TokenOfOwnerByIndex", reflect.TypeOf((*MockTree)(nil).TokenOfOwnerByIndex), owner, idx)
 }
 
 // Transfer mocks base method.

--- a/internal/platform/state/tree/enumerated/tree_test.go
+++ b/internal/platform/state/tree/enumerated/tree_test.go
@@ -1,6 +1,7 @@
 package enumerated_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -52,23 +53,23 @@ func TestTree(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Equal(t, tr.Root().String(), "0x0000000000000000000000000000000000000000000000000000000000000000")
 
-		tokens1, err := tr.TokensOf(common.HexToAddress("0x1"))
+		balance1, err := tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 0)
-		tokens2, err := tr.TokensOf(common.HexToAddress("0x2"))
+		assert.Equal(t, balance1, uint64(0))
+		balance2, err := tr.BalanceOfOwner(common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 0)
+		assert.Equal(t, balance2, uint64(0))
 
 		err = tr.Mint(big.NewInt(1), common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0x2869b4a1411aa86d60d937c481cb6b4843432fc6342efef13fbc82d1b2bd9db5")
+		assert.Equal(t, tr.Root().String(), "0xdbe504d75c24341e90d36073d631b7cc9ffdca8df2071e14a3c71c5b8c2ffd5b")
 
-		tokens1, err = tr.TokensOf(common.HexToAddress("0x1"))
+		balance1, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 0)
-		tokens2, err = tr.TokensOf(common.HexToAddress("0x2"))
+		assert.Equal(t, balance1, uint64(0))
+		balance2, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 1)
+		assert.Equal(t, balance2, uint64(1))
 
 		err = tr.Transfer(false, &model.ERC721Transfer{
 			From:    common.HexToAddress("0x1"),
@@ -77,13 +78,13 @@ func TestTree(t *testing.T) {
 		})
 
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0x2869b4a1411aa86d60d937c481cb6b4843432fc6342efef13fbc82d1b2bd9db5")
-		tokens1, err = tr.TokensOf(common.HexToAddress("0x1"))
+		assert.Equal(t, tr.Root().String(), "0xdbe504d75c24341e90d36073d631b7cc9ffdca8df2071e14a3c71c5b8c2ffd5b")
+		balance1, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 0)
-		tokens2, err = tr.TokensOf(common.HexToAddress("0x2"))
+		assert.Equal(t, balance1, uint64(0))
+		balance2, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 1)
+		assert.Equal(t, balance2, uint64(1))
 	})
 
 	t.Run(`mint tokens to address`, func(t *testing.T) {
@@ -96,22 +97,31 @@ func TestTree(t *testing.T) {
 
 		err = tr.Mint(big.NewInt(1), common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xd2776ed971a71a483a279ade441a20cb67374963ba95fef6874ab6f7cfa8a63a")
+		assert.Equal(t, tr.Root().String(), "0x5ce00d2afc3d832a1cd6383355aeb85283a0b0004fad0efc599324ed9057737b")
 
-		tokens, err := tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err := tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens), 1)
-		assert.Equal(t, tokens[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
+
+		token, err := tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 0)
+		assert.NilError(t, err)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
 
 		err = tr.Mint(big.NewInt(2), common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xe89b5bd33d239dde2e9d298c7ffea488eb63a0bd44b9fa39cba3deb383d470ec")
+		assert.Equal(t, tr.Root().String(), "0xdbaa67bf186eb370fafb60f542854bec45b56b2f6a29d83d6d206fddf5a7f8bd")
 
-		tokens, err = tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens), 2)
-		assert.Equal(t, tokens[0].Cmp(big.NewInt(1)), 0)
-		assert.Equal(t, tokens[1].Cmp(big.NewInt(2)), 0)
+		assert.Equal(t, balance, uint64(2))
+
+		token, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 0)
+		assert.NilError(t, err)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
+
+		token, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 1)
+		assert.NilError(t, err)
+		assert.Equal(t, token.Cmp(big.NewInt(2)), 0)
 	})
 
 	t.Run(`tokens minted in different contracts`, func(t *testing.T) {
@@ -124,14 +134,14 @@ func TestTree(t *testing.T) {
 
 		err = tr.Mint(big.NewInt(1), common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xd2776ed971a71a483a279ade441a20cb67374963ba95fef6874ab6f7cfa8a63a")
+		assert.Equal(t, tr.Root().String(), "0x5ce00d2afc3d832a1cd6383355aeb85283a0b0004fad0efc599324ed9057737b")
 
 		tr1, err := enumerated.NewTree(common.HexToAddress("0x501"), tx)
 		assert.NilError(t, err)
 
 		err = tr1.Mint(big.NewInt(1), common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr1.Root().String(), "0xd2776ed971a71a483a279ade441a20cb67374963ba95fef6874ab6f7cfa8a63a")
+		assert.Equal(t, tr1.Root().String(), "0x5ce00d2afc3d832a1cd6383355aeb85283a0b0004fad0efc599324ed9057737b")
 	})
 
 	t.Run(`transfer token  works correctly`, func(t *testing.T) {
@@ -144,16 +154,19 @@ func TestTree(t *testing.T) {
 
 		err = tr.Mint(big.NewInt(1), common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xd2776ed971a71a483a279ade441a20cb67374963ba95fef6874ab6f7cfa8a63a")
+		assert.Equal(t, tr.Root().String(), "0x5ce00d2afc3d832a1cd6383355aeb85283a0b0004fad0efc599324ed9057737b")
 
-		tokens1, err := tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err := tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 1)
-		assert.Equal(t, tokens1[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
 
-		tokens2, err := tr.TokensOf(common.HexToAddress("0x2"))
+		token, err := tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 0)
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 0)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
+
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
+		assert.NilError(t, err)
+		assert.Equal(t, balance, uint64(0))
 
 		err = tr.Transfer(true, &model.ERC721Transfer{
 			From:    common.HexToAddress("0x1"),
@@ -161,16 +174,22 @@ func TestTree(t *testing.T) {
 			TokenId: big.NewInt(1),
 		})
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xb899cb3fcae2117e1eaffa7652259f348844200f51d1b00712ff677869d8f5ca")
+		assert.Equal(t, tr.Root().String(), "0x5a8a15f0f6e2e2c551e0dadfb31c1f1d2f08377328eb20812e6e3df86b979218")
 
-		tokens1, err = tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 0)
+		assert.Equal(t, balance, uint64(0))
 
-		tokens2, err = tr.TokensOf(common.HexToAddress("0x2"))
+		_, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 0)
+		assert.Error(t, fmt.Errorf("index 0 out of range"), err.Error())
+
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 1)
-		assert.Equal(t, tokens2[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
+
+		token, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x2"), 0)
+		assert.NilError(t, err)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
 	})
 }
 
@@ -186,19 +205,22 @@ func TestTag(t *testing.T) {
 
 		err = tr.Mint(big.NewInt(1), common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xd2776ed971a71a483a279ade441a20cb67374963ba95fef6874ab6f7cfa8a63a")
+		assert.Equal(t, tr.Root().String(), "0x5ce00d2afc3d832a1cd6383355aeb85283a0b0004fad0efc599324ed9057737b")
 
 		err = tr.TagRoot(1)
 		assert.NilError(t, err)
 
-		tokens1, err := tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err := tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 1)
-		assert.Equal(t, tokens1[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
 
-		tokens2, err := tr.TokensOf(common.HexToAddress("0x2"))
+		token, err := tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 0)
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 0)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
+
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
+		assert.NilError(t, err)
+		assert.Equal(t, balance, uint64(0))
 
 		err = tr.Transfer(true, &model.ERC721Transfer{
 			From:    common.HexToAddress("0x1"),
@@ -206,42 +228,51 @@ func TestTag(t *testing.T) {
 			TokenId: big.NewInt(1),
 		})
 		assert.NilError(t, err)
-		assert.Equal(t, tr.Root().String(), "0xb899cb3fcae2117e1eaffa7652259f348844200f51d1b00712ff677869d8f5ca")
+		assert.Equal(t, tr.Root().String(), "0x5a8a15f0f6e2e2c551e0dadfb31c1f1d2f08377328eb20812e6e3df86b979218")
 		err = tr.TagRoot(2)
 		assert.NilError(t, err)
 
-		tokens1, err = tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 0)
+		assert.Equal(t, balance, uint64(0))
 
-		tokens2, err = tr.TokensOf(common.HexToAddress("0x2"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 1)
-		assert.Equal(t, tokens2[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
+
+		token, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x2"), 0)
+		assert.NilError(t, err)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
 
 		err = tr.Checkout(1)
 		assert.NilError(t, err)
 
-		tokens1, err = tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 1)
-		assert.Equal(t, tokens1[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
 
-		tokens2, err = tr.TokensOf(common.HexToAddress("0x2"))
+		token, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x1"), 0)
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 0)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
+
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
+		assert.NilError(t, err)
+		assert.Equal(t, balance, uint64(0))
 
 		err = tr.Checkout(2)
 		assert.NilError(t, err)
 
-		tokens1, err = tr.TokensOf(common.HexToAddress("0x1"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x1"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens1), 0)
+		assert.Equal(t, balance, uint64(0))
 
-		tokens2, err = tr.TokensOf(common.HexToAddress("0x2"))
+		balance, err = tr.BalanceOfOwner(common.HexToAddress("0x2"))
 		assert.NilError(t, err)
-		assert.Equal(t, len(tokens2), 1)
-		assert.Equal(t, tokens2[0].Cmp(big.NewInt(1)), 0)
+		assert.Equal(t, balance, uint64(1))
+
+		token, err = tr.TokenOfOwnerByIndex(common.HexToAddress("0x2"), 0)
+		assert.NilError(t, err)
+		assert.Equal(t, token.Cmp(big.NewInt(1)), 0)
 	})
 
 	t.Run(`tag root before transfer. checkout at block which tag does not exist returns error`, func(t *testing.T) {

--- a/internal/platform/state/tree/ownership/tree.go
+++ b/internal/platform/state/tree/ownership/tree.go
@@ -100,6 +100,10 @@ func (b *tree) Mint(mintEvent *model.MintedWithExternalURI, idx int) error {
 		return err
 	}
 
+	if tokenData.Minted {
+		return errors.New("token " + mintEvent.TokenId.String() + " already minted")
+	}
+
 	tokenData.Minted = true
 	tokenData.Idx = idx
 	tokenData.TokenURI = mintEvent.TokenURI

--- a/internal/platform/state/v1/state.go
+++ b/internal/platform/state/v1/state.go
@@ -134,12 +134,12 @@ func (t *tx) BalanceOf(contract, owner common.Address) (*big.Int, error) {
 		return big.NewInt(0), fmt.Errorf("contract %s does not exist", contract.String())
 	}
 
-	tokens, err := enumeratedTree.TokensOf(owner)
+	balance, err := enumeratedTree.BalanceOfOwner(owner)
 	if err != nil {
 		return big.NewInt(0), err
 	}
 
-	return big.NewInt(int64(len(tokens))), nil
+	return big.NewInt(int64(balance)), nil
 }
 
 // TokenOfOwnerByIndex returns the token of the owner by index
@@ -150,14 +150,7 @@ func (t *tx) TokenOfOwnerByIndex(contract, owner common.Address, idx int) (*big.
 		return big.NewInt(0), fmt.Errorf("contract %s does not exist", contract.String())
 	}
 
-	tokens, err := enumeratedTree.TokensOf(owner)
-	if err != nil {
-		return big.NewInt(0), err
-	}
-	if idx >= len(tokens) {
-		return big.NewInt(0), fmt.Errorf("index %d out of range", idx)
-	}
-	return &tokens[idx], nil
+	return enumeratedTree.TokenOfOwnerByIndex(owner, uint64(idx))
 }
 
 // Transfer transfers ownership of the token. From, To, and TokenID are set in event
@@ -267,7 +260,6 @@ func (t *tx) Mint(contract common.Address, mintEvent *model.MintedWithExternalUR
 	if !ok {
 		return fmt.Errorf("contract %s does not exist", contract.String())
 	}
-
 	return enumeratedTree.Mint(mintEvent.TokenId, tokenData.SlotOwner)
 }
 

--- a/internal/platform/storage/badger/badger_test.go
+++ b/internal/platform/storage/badger/badger_test.go
@@ -12,6 +12,8 @@ import (
 	badgerStorage "github.com/freeverseio/laos-universal-node/internal/platform/storage/badger"
 )
 
+const prefix = "prefix_"
+
 var db *badger.DB // badger.DB is thread-safe
 
 func TestMain(m *testing.M) {
@@ -150,7 +152,7 @@ func TestStorageGetNoKeysWithPrefixWithValues(t *testing.T) {
 		}
 	}
 	tx := service.NewTransaction()
-	got := tx.GetKeysWithPrefix([]byte("prefix_"), false)
+	got := tx.GetKeysWithPrefix([]byte(prefix), false)
 
 	if len(got) != 7 {
 		t.Fatalf("got %d keys when 7 keys were expected", len(got))
@@ -171,13 +173,13 @@ func TestStorageGetNoKeysWithPrefixReverse(t *testing.T) {
 	service := badgerStorage.NewService(db)
 
 	for i := 0; i < 1000; i++ {
-		err := service.Set([]byte("prefix_"+strconv.Itoa(i)), []byte(strconv.Itoa(i)))
+		err := service.Set([]byte(prefix+strconv.Itoa(i)), []byte(strconv.Itoa(i)))
 		if err != nil {
 			t.Fatalf("got error %s, expecting no error", err.Error())
 		}
 	}
 	tx := service.NewTransaction()
-	got := tx.GetKeysWithPrefix([]byte("prefix_"), true)
+	got := tx.GetKeysWithPrefix([]byte(prefix), true)
 	if len(got) != 1000 {
 		t.Fatalf("got %d keys when 1000 keys were expected", len(got))
 	}
@@ -204,7 +206,7 @@ func TestFilterKeysWithPrefix(t *testing.T) {
 		}
 	}
 	tx := service.NewTransaction()
-	got := tx.FilterKeysWithPrefix([]byte("prefix_"), "002", "005")
+	got := tx.FilterKeysWithPrefix([]byte(prefix), "002", "005")
 
 	if len(got) != 4 {
 		t.Fatalf("got %d keys when 7 keys were expected", len(got))
@@ -220,14 +222,14 @@ func TestFilterKeysWithPrefixWithValues(t *testing.T) {
 	service := badgerStorage.NewService(db)
 	for i := 0; i < 100; i++ {
 		formatedBlockNumber := formatBlockNumber(uint64(i))
-		err := service.Set([]byte("prefix_"+formatedBlockNumber), []byte(strconv.Itoa(i)))
+		err := service.Set([]byte(prefix+formatedBlockNumber), []byte(strconv.Itoa(i)))
 		if err != nil {
 			t.Fatalf("got error %s, expecting no error", err.Error())
 		}
 	}
 
 	tx := service.NewTransaction()
-	got := tx.FilterKeysWithPrefix([]byte("prefix_"), formatBlockNumber(uint64(6)), formatBlockNumber(uint64(10)))
+	got := tx.FilterKeysWithPrefix([]byte(prefix), formatBlockNumber(uint64(6)), formatBlockNumber(uint64(10)))
 
 	if len(got) != 5 {
 		t.Fatalf("got %d keys when 7 keys were expected", len(got))
@@ -243,14 +245,14 @@ func TestGetValuesWithPrefixWithValues(t *testing.T) {
 	service := badgerStorage.NewService(db)
 	for i := 0; i < 100; i++ {
 		formatedBlockNumber := formatBlockNumber(uint64(i))
-		err := service.Set([]byte("prefix_"+formatedBlockNumber), []byte(strconv.Itoa(i)))
+		err := service.Set([]byte(prefix+formatedBlockNumber), []byte(strconv.Itoa(i)))
 		if err != nil {
 			t.Fatalf("got error %s, expecting no error", err.Error())
 		}
 	}
 
 	tx := service.NewTransaction()
-	got := tx.GetValuesWithPrefix([]byte("prefix_"), false)
+	got := tx.GetValuesWithPrefix([]byte(prefix), false)
 
 	if len(got) != 100 {
 		t.Fatalf("got %d keys when 7 keys were expected", len(got))


### PR DESCRIPTION
Optimization of enumerated Merkle tree. 

- don't store all the array of tokens in a leaf. store just one token per leaf, the same way as in enumerated total.
- this significantly increases the number of assets that we can store in a Merkle tree. 
- For transaction size of 150MB, and 10000 mints per block we were able to store up to 830000 assets can be store
- If the number of mints per block is smaller number increases even more.

without this implementation, we were able to store up to 30000 assets for the same conditions (more than 25x improvement)