### PR TITLE
turn of bloom filter cache and compression for badger

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"golang.org/x/sync/errgroup"
 
@@ -75,7 +76,13 @@ func run() error {
 	c.LogFields()
 
 	// "WithMemTableSize" increases MemTableSize to 1GB (1<<30 is 1GB). This increases the transaction size to about 153MB (15% of MemTableSize)
-	db, err := badger.Open(badger.DefaultOptions(dbPath).WithLoggingLevel(badger.ERROR).WithMemTableSize(1 << 30))
+	db, err := badger.Open(badger.DefaultOptions(dbPath).
+		WithCompression(options.None).
+		WithBlockCacheSize(0).
+		WithBloomFalsePositive(0).
+		WithLoggingLevel(badger.ERROR).
+		WithMemTableSize(1 << 30))
+
 	if err != nil {
 		return fmt.Errorf("error initializing storage: %w", err)
 	}

--- a/internal/platform/state/v1/state_integration_test.go
+++ b/internal/platform/state/v1/state_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v4"
+	"github.com/dgraph-io/badger/v4/options"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/freeverseio/laos-universal-node/internal/platform/model"
 	"github.com/freeverseio/laos-universal-node/internal/platform/state"
@@ -185,8 +186,11 @@ func createBadger(t *testing.T) *badger.DB {
 	t.Helper()
 	db, err := badger.Open(
 		badger.DefaultOptions("").
-			WithInMemory(true).
-			WithLoggingLevel(badger.ERROR).WithMemTableSize(1 << 30))
+		WithInMemory(true).
+		WithCompression(options.None).
+		WithBlockCacheSize(0).
+		WithBloomFalsePositive(0).
+		WithLoggingLevel(badger.ERROR).WithMemTableSize(1 << 30))
 	if err != nil {
 		t.Fatalf("error initializing storage: %v", err)
 	}


### PR DESCRIPTION
issue with RAM spike is mostly solved when bloom filter was turned off